### PR TITLE
Commitlint header length

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @mrdoodles
+* @oberiworks/platform-and-tooling

--- a/.github/config/commitlint.yml
+++ b/.github/config/commitlint.yml
@@ -5,7 +5,7 @@ rules:
   subject-full-stop: [0, "never", "."]
   subject-case: [0, "always", "sentence-case"]
   header-full-stop: [0, "never", "."]
-  header-max-length: [1, "always", 72]
+  header-max-length: [1, "always", 100]
   type-enum:
     - 2
     - always

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    commit-message:
+      prefix: chore
+      prefix-development: chore
+      include: scope
+    target-branch: main
+    labels:
+    - dependabot

--- a/.github/workflows/validate-code.yml
+++ b/.github/workflows/validate-code.yml
@@ -81,7 +81,7 @@ jobs:
         if: ${{ inputs.workflowlint == true }}
         uses: rethab/actions-lint@v1
         with:
-          files: '[".github/workflows/*.yaml"]'
+          files: '[".github/workflows/*.yml"]'
 
       # Yaml
       - name: Lint yaml files


### PR DESCRIPTION
# Summary

## Description

Updated to enable dependabot long header messagesin validation
Added codeowners for security
Enabled dependabot for workflow actions

### Motivation and Context

This enables tests to pass when dependabot contains a long header

## Issue tracking

None

## Testing

None

## Checklists

### Work checklists

- [X] I have updated my branch with main.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
