### PR TITLE
fix(dependabot): increase max lengty to 200 for dependabot

### DIFF
--- a/.github/config/commitlint.yml
+++ b/.github/config/commitlint.yml
@@ -5,7 +5,7 @@ rules:
   subject-full-stop: [0, "never", "."]
   subject-case: [0, "always", "sentence-case"]
   header-full-stop: [0, "never", "."]
-  header-max-length: [1, "always", 100]
+  header-max-length: [1, "always", 200]
   type-enum:
     - 2
     - always


### PR DESCRIPTION
# Summary

## Description

Increased header length to 200

### Motivation and Context

To fix dependabot with conventional commits

## Issue tracking

None

## Testing

None

## Checklists

### Work checklists

- [X] I have updated my branch with main.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
