### PR TITLE
fix(dependabot): body line max lengty to 200 for dependabot

### DIFF
--- a/.github/config/commitlint.yml
+++ b/.github/config/commitlint.yml
@@ -6,6 +6,7 @@ rules:
   subject-case: [0, "always", "sentence-case"]
   header-full-stop: [0, "never", "."]
   header-max-length: [1, "always", 200]
+  body-max-line-length: [1, "always", 200]
   type-enum:
     - 2
     - always


### PR DESCRIPTION
# Summary

## Description

Increase body line length to 200 for depenabot

### Motivation and Context

Fix line length validation

## Issue tracking

None

## Testing

None

## Checklists

### Work checklists

- [X] I have updated my branch with main.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [X] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
